### PR TITLE
Add Discord to socials

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -71,6 +71,7 @@ networks = [
   ,"twitter"
   ,"facebook"
   ,"youtube"
+  ,"discord"
 ]
 
 [params.ananke.social.share]
@@ -96,6 +97,10 @@ username = "base205al"
 username = "people/BASE-Birmingham-Area-Software-Enthusiasts/61575048102778/"
 [params.ananke.social.youtube]
 username = "BASE205AL"
+# Discord invite code (the path after discord.gg/). The networks.discord
+# `profile` template below turns this into https://discord.gg/USuQrTz5tA.
+[params.ananke.social.discord]
+username = "USuQrTz5tA"
 
 
 [params.ananke.social.linkedin]
@@ -128,6 +133,16 @@ url = "permalink"
 link = "https://mastodon.social/share"
 [params.ananke.social.networks.mastodon.particles]
 text = "permalink"
+
+# The theme ships a discord.svg icon but no `networks.discord` definition, so
+# we supply one here. `profile` is a printf template filled with the invite
+# code from [params.ananke.social.discord].username → https://discord.gg/<code>.
+[params.ananke.social.networks.discord]
+slug = "discord"
+label = "Discord"
+color = "#5865F2"
+profile = "https://discord.gg/%s"
+icon = "discord"
 
 [services]
   [services.rss]


### PR DESCRIPTION
Adds a Discord follow icon to the social links row, pointing to the community invite <https://discord.gg/USuQrTz5tA>.

### What changed
`config/_default/hugo.toml` only:
- Added `"discord"` to `params.ananke.social.follow.networks`
- Added `[params.ananke.social.discord]` with the invite code as `username`
- Added a `[params.ananke.social.networks.discord]` definition (the theme has none)

### Icon
Uses the Ananke theme's built-in `discord.svg` (the official Discord logo, same Simple Icons source as `youtube.svg`) — no new asset files. Renders monochrome, consistent with the rest of the row. This mirrors how YouTube was added in #28.

### Testing
Built with `hugo --gc --minify` and verified locally with `hugo server` — the icon appears at the end of the header and footer socials and links to the invite in a new tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="306" height="252" alt="discord" src="https://github.com/user-attachments/assets/3377b6eb-5305-4d12-b60d-507ba467418c" />
